### PR TITLE
Changed get_template_directory to get_stylesheet_directory

### DIFF
--- a/acf-contact-form-settings.php
+++ b/acf-contact-form-settings.php
@@ -373,9 +373,9 @@
 
 
 			function acf_load_templates( $field ) {
-				if(file_exists(get_template_directory() . '/acf-cf-templates')) {
+				if(file_exists(get_stylesheet_directory() . '/acf-cf-templates')) {
 				// reset choices
-				$files = scandir(get_template_directory() . '/acf-cf-templates');
+				$files = scandir(get_stylesheet_directory() . '/acf-cf-templates');
 
 				if(!empty($files)) {
 					foreach($files as $file) {

--- a/acf-contact-process.php
+++ b/acf-contact-process.php
@@ -34,7 +34,7 @@ function save_inquiry( $post_id ) {
 					
 					
 	
-					$headers = array('Content-Type: text/html; charset=UTF-8');
+					$headers = array('Content-Type: text/html; charset=UTF-8', 'From: '.get_bloginfo('name').' <noreply@'.$_SERVER['HTTP_HOST'].'>');
 	
 					$subject = $title . ' (' . $post_id . ')';
 

--- a/acf-contact-render-email.php
+++ b/acf-contact-render-email.php
@@ -240,7 +240,7 @@
 	
 			} else {
 				$template = $_GET['template'];
-				$template = get_template_directory() . '/acf-cf-templates/acf-cf-' . $template . '.php';
+				$template = get_stylesheet_directory() . '/acf-cf-templates/acf-cf-' . $template . '.php';
 				require_once($template);
 	
 			}
@@ -308,7 +308,7 @@
 	
 			} else {
 				$template = $_GET['customertemplate'];
-				$template = get_template_directory() . '/acf-cf-templates/acf-cf-' . $template . '.php';
+				$template = get_stylesheet_directory() . '/acf-cf-templates/acf-cf-' . $template . '.php';
 				require_once($template);
 	
 			}

--- a/acf-contact-shortcode.php
+++ b/acf-contact-shortcode.php
@@ -17,7 +17,13 @@
 
 	//[acf_contact] shortcode
 	function acf_contact_shortcode( $atts ) {
-
+		//This code uses acf_form() function which immediately outputs form html
+		//messing up the admin view of the page containing the shortcode
+		//For this reason I check if the current page "is_admin" page and return 
+		//immediately to avoid shortcode rendering.
+		if ( is_admin() )
+                        return false;
+                        
 		$url = acf_get_current_url();
 		
 		// default shortcode attribute values 


### PR DESCRIPTION
I changed `get_template_directory` to `get_stylesheet_directory` to make the plugin compatible with child themes.

https://codex.wordpress.org/Function_Reference/get_template_directory

_In the case a child theme is being used, the absolute path to the parent theme directory will be returned. Use get_stylesheet_directory() to get the absolute path to the child theme directory._